### PR TITLE
Add locale to time_ago_in_words in latest activity section

### DIFF
--- a/app/views/active_storage_dashboard/dashboard/index.html.erb
+++ b/app/views/active_storage_dashboard/dashboard/index.html.erb
@@ -106,7 +106,7 @@
                 <div class="activity-content">
                   <div class="activity-title"><%= blob.filename %></div>
                   <div class="activity-meta">
-                    <span class="activity-time"><%= time_ago_in_words(blob.created_at) %> ago</span>
+                    <span class="activity-time"><%= time_ago_in_words(blob.created_at, locale: :en) %> ago</span>
                     <span class="activity-size"><%= format_bytes(blob.byte_size) %></span>
                   </div>
                   <div class="activity-actions">


### PR DESCRIPTION
Ensure the time_ago_in_words helper explicitly uses the English locale, preventing translation-missing errors when the host application sets a different locale than English.

![image](https://github.com/user-attachments/assets/1047ebbe-723a-473d-9329-2233337ee755)


